### PR TITLE
fix: replace next lint with eslint for Next.js 16 compatibility

### DIFF
--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -10,6 +10,9 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  {
+    ignores: [".next/**", "out/**", "node_modules/**"],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];
 

--- a/src/package.json
+++ b/src/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "export": "next export",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Next.js 16 removed the `next lint` CLI command. Updated the lint script to use ESLint directly and added ignores for build directories (.next, out, node_modules) in eslint.config.mjs.