### PR TITLE
fix(lint): remove unused icon imports in Education, Experience, Projects

### DIFF
--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { GraduationCap, BookOpen } from "lucide-react";
+import { GraduationCap } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { TFunction } from "i18next";
 import { cn } from "@/lib/utils";

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { Building2, Gem } from "lucide-react";
+import { Building2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Badge } from "@/components/ui/badge";
 import { TFunction } from "i18next";

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { FolderKanban, Gem, ExternalLink, Github } from "lucide-react";
+import { FolderKanban, ExternalLink, Github } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { TFunction } from "i18next";
 import { cn } from "@/lib/utils";


### PR DESCRIPTION
## Summary
- Remove unused `BookOpen` import in `Education.tsx`
- Remove unused `Gem` import in `Experience.tsx` and `Projects.tsx`

These unused imports were causing ESLint `@typescript-eslint/no-unused-vars` errors that blocked CI on the Dependabot PRs (#36, #38).

## Test plan
- [ ] CI lint check passes
- [ ] Dependabot PRs #36 and #38 can be merged after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)