### PR TITLE
fix(ci): use ghcr.io as Trivy DB source to avoid MCR 403 block

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -24,6 +24,8 @@ jobs:
   trivy-fs-scan:
     name: Trivy Filesystem Scan
     runs-on: ubuntu-latest
+    env:
+      TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2` at the job level in `trivy-scan.yml`

## Root cause
All Trivy scans were failing with:
```
FATAL: failed to download artifact from mcr.microsoft.com/oss/v2/aquasecurity/trivy-db:2
GET https://mcr.microsoft.com/v2/: unexpected status code 403 Forbidden: The request is blocked.
```
`mcr.microsoft.com` (Microsoft Container Registry) is blocking GitHub Actions runners from downloading the Trivy vulnerability DB. This is an infrastructure-level block, not a code issue.

## Fix
Set `TRIVY_DB_REPOSITORY` to the `ghcr.io` mirror at the job level so all three `trivy-action` steps automatically use GitHub Container Registry instead of MCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)