### PR TITLE
chore(ci): add dependabot.yml to control update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/src"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Taipei"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    ignore:
+      # Major version bumps require manual review
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Taipei"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` to explicitly configure Dependabot update targets
- Weekly npm updates for `/src` every Monday at 09:00 Asia/Taipei time
- Weekly GitHub Actions updates on the same schedule
- Blocks automatic major version bumps for `next`, `react`, and `react-dom` (require manual review)

## Test plan

- [ ] Confirm Dependabot picks up the config and opens PRs on the next Monday schedule
- [ ] Verify auto-approve/merge workflow still triggers on Dependabot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)