### PR TITLE
fix(ci): add workflows permission for Dependabot action bump auto-merge

### DIFF
--- a/.github/workflows/dependabot-pr-check.yml
+++ b/.github/workflows/dependabot-pr-check.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   check:


### PR DESCRIPTION
## Summary

- Add `workflows: write` to permissions in `dependabot-pr-check.yml`

## Root cause

PRs #44 (`actions/cache`) and #47 (`actions/upload-pages-artifact`) modify `.github/workflows/` files. GitHub requires `workflows` permission on `GITHUB_TOKEN` to merge such PRs — without it the auto-merge step fails with:

```
Pull request refusing to allow a GitHub App to create or update workflow
`.github/workflows/deploy.yml` without `workflows` permission
```

## Change

One-line addition to the `permissions` block:
```yaml
permissions:
  contents: write
  pull-requests: write
  workflows: write   # ← added
```

## Test plan

- [ ] Merge this PR
- [ ] Re-run #44 and #47 — auto-merge should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)