### PR TITLE
fix(ci): remove workflows:write to unblock Dependabot push trigger

### DIFF
--- a/.github/workflows/dependabot-pr-check.yml
+++ b/.github/workflows/dependabot-pr-check.yml
@@ -19,7 +19,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   check:
@@ -56,7 +55,7 @@ jobs:
         with:
           node-version: "lts/*"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
-          cache-dependency-path: src/package-lock.json
+          cache-dependency-path: ${{ steps.detect-package-manager.outputs.manager == 'yarn' && 'src/yarn.lock' || 'src/package-lock.json' }}
 
       - name: Restore cache
         uses: actions/cache@v5
@@ -71,10 +70,10 @@ jobs:
         run: cd src && ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
 
       - name: Run lint
-        run: cd src && npm run lint
+        run: cd src && ${{ steps.detect-package-manager.outputs.manager }} run lint
 
       - name: Build with Next.js
-        run: cd src && npm run build
+        run: cd src && ${{ steps.detect-package-manager.outputs.manager }} run build
 
       - name: Resolve PR URL
         id: resolve-pr


### PR DESCRIPTION
## Problem

PR #81 added a \`push: branches: ["dependabot/**"]\` trigger as a fallback, but all Dependabot branch runs still showed "workflow file issue" with 0 jobs. The root cause: **GitHub blocks workflows with \`workflows: write\` permission from running on push events from Dependabot branches** (security restriction — write permissions + untrusted branch code = potential workflow injection).

## Fix

Remove \`workflows: write\` from the top-level permissions. \`contents: write\` + \`pull-requests: write\` are sufficient to lint, build, approve, and squash-merge npm/dependency PRs.

Also applies linter suggestions:
- \`cache-dependency-path\` now uses a conditional expression per detected package manager
- Lint and build steps use \`\${{ steps.detect-package-manager.outputs.manager }}\` variable

## Trade-off

PRs that modify workflow files (#69 \`actions/checkout v6\`, #70 \`configure-pages v6\`) **cannot be auto-merged** without the \`workflow\` OAuth scope — those two require a manual merge from the web UI after CI passes.

All npm/dependency PRs (#71–#80) will auto-approve and auto-merge via the push trigger.

## Test plan

- [ ] Merge this PR
- [ ] Trigger \`@dependabot rebase\` on npm PRs #71–#80
- [ ] Verify \`check\` job runs and auto-merges them
- [ ] Merge #69 and #70 manually from web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)