### PR TITLE
chore(deps): block eslint major version bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
+      # eslint v10 removed context.getFilename(); incompatible with eslint-plugin-react
+      # bundled in eslint-config-next until the bundled plugin is updated
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Closes #78 fallout. eslint v10 is incompatible with `eslint-plugin-react` bundled in `eslint-config-next@16` — v10 removed `context.getFilename()` which the plugin still calls. Adding to the major-bump ignore list alongside `next`/`react`/`react-dom`.