### PR TITLE
fix(ci): pin Node version instead of lts/* in setup-node

### DIFF
--- a/.github/workflows/dependabot-pr-check.yml
+++ b/.github/workflows/dependabot-pr-check.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: "lts/*"
+          node-version: "22.x"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
           cache-dependency-path: ${{ steps.detect-package-manager.outputs.manager == 'yarn' && 'src/yarn.lock' || 'src/package-lock.json' }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: "lts/*"
+          node-version: "22.x"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
           cache-dependency-path: src/package-lock.json
 


### PR DESCRIPTION
## Summary
- `actions/setup-node` intermittently throws `manifest.filter is not a function` when resolving `node-version: "lts/*"` (actions/setup-node#1162)
- This caused the Dependabot PR check job to fail on run 29710520516 (PR #161), before lint/build even ran
- Pin `node-version` to `22.x` in both `dependabot-pr-check.yml` and `deploy.yml` to avoid the flaky LTS-alias resolution

## Test plan
- [x] Re-ran the previously failing job after diagnosis to confirm the wildcard resolution was the culprit
- [ ] Confirm `Setup Node` step succeeds on next CI run with this branch