### PR TITLE
fix(ci): allow dependabot bot to trigger Claude Code fix step

### DIFF
--- a/.github/workflows/dependabot-pr-check.yml
+++ b/.github/workflows/dependabot-pr-check.yml
@@ -94,6 +94,7 @@ jobs:
             5. Commit all changes with a descriptive message such as "fix: resolve <package> vX breaking changes"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_bots: dependabot[bot]
 
       - name: Auto-approve PR
         if: success()


### PR DESCRIPTION
## Summary
- `claude-code-action@v1` added an `allowed_bots` guard that blocks bot-triggered runs by default
- The Dependabot PR check job (already gated to `github.actor == 'dependabot[bot]'`) was failing the "Fix with Claude Code" step with `Workflow initiated by non-human actor: dependabot`
- Explicitly allow `dependabot[bot]` since the job is already restricted to that actor

Found while investigating run 29217232349 (job 86715372337, PR #144).

## Test plan
- [ ] Confirm the "Fix with Claude Code" step no longer fails on `allowed_bots` for the next Dependabot PR with lint/build failures