### PR TITLE
fix: override postcss to resolve nested CVE

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -10065,34 +10065,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.47",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
@@ -10410,10 +10382,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
-      "dev": true,
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/package.json
+++ b/src/package.json
@@ -60,7 +60,8 @@
   },
   "overrides": {
     "lodash": "^4.18.0",
-    "sharp": "^0.35.0"
+    "sharp": "^0.35.0",
+    "postcss": "^8.5.18"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
Fixes #172 (Trivy scan, 2026-07-26): `postcss@8.4.31` flagged for [GHSA-r28c-9q8g-f849](https://avd.aquasec.com/nvd/ghsa-r28c-9q8g-f849) and [CVE-2026-45623](https://avd.aquasec.com/nvd/cve-2026-45623).

The top-level `postcss` (via tailwindcss) was already patched at `8.5.20` after #171, but `next` bundles its own nested copy pinned to an exact `8.4.31` (`node_modules/next/node_modules/postcss`) for its internal CSS pipeline — that's the copy Trivy was actually flagging. Adding `postcss` to the `overrides` block dedupes both instances into a single patched copy (now resolves to `8.5.23`).

Fixes #172

## Test plan
- [x] `npm install` — nested `next/node_modules/postcss` is gone, single top-level copy at 8.5.23
- [x] `npm run lint` — passes (1 pre-existing unrelated warning)
- [x] `npm run build` — succeeds, all 4 static routes generated